### PR TITLE
refactored creating the endpoints

### DIFF
--- a/src/components/AddNewTask.tsx
+++ b/src/components/AddNewTask.tsx
@@ -1,50 +1,75 @@
-import { Paper, TextField, IconButton, Box, CircularProgress } from "@mui/material";
-import { AddTask } from "@mui/icons-material";
-import { FormEvent, useEffect, useState } from "react";
-import { useSnackbar } from "notistack";
-import useTaskQueryHook from "../redux/hooks/useTaskQueryHook";
+import {
+  Paper,
+  TextField,
+  IconButton,
+  Box,
+  CircularProgress,
+} from "@mui/material"
+import { AddTask } from "@mui/icons-material"
+import { FormEvent, useEffect, useState } from "react"
+import { useSnackbar } from "notistack"
+import useTaskQueryHook from "../redux/hooks/useTaskQueryHook"
 
 const AddNewTask = () => {
-    const [taskTitle, setTaskTitle] = useState("");
-    const { enqueueSnackbar } = useSnackbar();
-    const { addTask, isAddingTask, isAddedTaskSuccess, addTaskAns, isAddingTaskError, addTaskError } = useTaskQueryHook();
+  const [taskTitle, setTaskTitle] = useState("")
+  const { enqueueSnackbar } = useSnackbar()
+  const {
+    addTask,
+    isAddingTask,
+    isAddedTaskSuccess,
+    addTaskAns,
+    isAddingTaskError,
+    addTaskError,
+  } = useTaskQueryHook()
 
-    useEffect(() => {
-        if (isAddedTaskSuccess) {
-            enqueueSnackbar(`Added: ${addTaskAns.title}`, { variant: "success" });
-            setTaskTitle("");
-        } else if (isAddingTaskError) {
-            enqueueSnackbar((addTaskError as { message: string }).message, { variant: "error" });
-        }
-    }, [isAddedTaskSuccess, isAddingTaskError, addTaskAns, addTaskError, enqueueSnackbar]);
+  useEffect(() => {
+    if (isAddedTaskSuccess) {
+      enqueueSnackbar(`Added: ${addTaskAns?.title}`, { variant: "success" })
+      setTaskTitle("")
+    } else if (isAddingTaskError) {
+      enqueueSnackbar((addTaskError as { message: string }).message, {
+        variant: "error",
+      })
+    }
+  }, [
+    isAddedTaskSuccess,
+    isAddingTaskError,
+    addTaskAns,
+    addTaskError,
+    enqueueSnackbar,
+  ])
 
-    const addNewTask = async (e: FormEvent) => {
-        e.preventDefault();
-        addTask(taskTitle);
-    };
+  const addNewTask = async (e: FormEvent) => {
+    e.preventDefault()
+    addTask({ title: taskTitle })
+  }
 
-    return (
-        <Paper elevation={5}>
-            <Box component="form" onSubmit={addNewTask} sx={{ display: "flex", alignItems: "center" }}>
-                <TextField
-                    id="newTask"
-                    variant="outlined"
-                    color="primary"
-                    placeholder="Add new Task..."
-                    value={taskTitle}
-                    onChange={(e) => setTaskTitle(e.target.value)}
-                    sx={{ "& fieldset": { border: "none" } }}
-                    margin="dense"
-                    fullWidth
-                    autoFocus
-                />
+  return (
+    <Paper elevation={5}>
+      <Box
+        component="form"
+        onSubmit={addNewTask}
+        sx={{ display: "flex", alignItems: "center" }}
+      >
+        <TextField
+          id="newTask"
+          variant="outlined"
+          color="primary"
+          placeholder="Add new Task..."
+          value={taskTitle}
+          onChange={(e) => setTaskTitle(e.target.value)}
+          sx={{ "& fieldset": { border: "none" } }}
+          margin="dense"
+          fullWidth
+          autoFocus
+        />
 
-                <IconButton type="submit" size="medium" sx={{ mr: 0.5 }}>
-                    {isAddingTask ? <CircularProgress size={25} /> : <AddTask />}
-                </IconButton>
-            </Box>
-        </Paper>
-    );
-};
+        <IconButton type="submit" size="medium" sx={{ mr: 0.5 }}>
+          {isAddingTask ? <CircularProgress size={25} /> : <AddTask />}
+        </IconButton>
+      </Box>
+    </Paper>
+  )
+}
 
-export default AddNewTask;
+export default AddNewTask

--- a/src/redux/api.tools.ts
+++ b/src/redux/api.tools.ts
@@ -1,0 +1,151 @@
+import type {
+  BaseQueryFn,
+  EndpointBuilder,
+  FetchArgs,
+  FetchBaseQueryError,
+  FetchBaseQueryMeta,
+  MutationDefinition,
+  QueryDefinition,
+} from "@reduxjs/toolkit/query"
+import type { ErrorInfo, FindOptions, Repository } from "remult"
+
+type Pluralize<T extends string> = T extends `${infer S}s`
+  ? `${S}ses` // Cases like "class" -> "classes"
+  : T extends `${infer S}y`
+  ? `${S}ies` // Cases like "category" -> "categories"
+  : T extends `${infer S}`
+  ? `${S}s` // Default pluralization
+  : never
+
+export type NameActions<
+  EntityType,
+  TagName extends string,
+  ReducerPath extends string
+> = {
+  [K in `get${Capitalize<Pluralize<TagName>>}`]: QueryDefinition<
+    FindOptions<EntityType>,
+    BaseQueryFn<
+      string | FetchArgs,
+      unknown,
+      FetchBaseQueryError,
+      NonNullable<unknown>,
+      FetchBaseQueryMeta
+    >,
+    TagName,
+    EntityType[] | undefined,
+    ReducerPath
+  >
+}
+  & {
+    [K in `add${Capitalize<TagName>}`]: MutationDefinition<
+      Partial<EntityType>,
+      BaseQueryFn<
+        string | FetchArgs,
+        unknown,
+        FetchBaseQueryError,
+        unknown,
+        FetchBaseQueryMeta
+      >,
+      TagName,
+      EntityType,
+      ReducerPath
+    >
+  } & {
+    [K in `update${Capitalize<TagName>}`]: MutationDefinition<
+      Partial<EntityType>,
+      BaseQueryFn<
+        string | FetchArgs,
+        unknown,
+        FetchBaseQueryError,
+        unknown,
+        FetchBaseQueryMeta
+      >,
+      TagName,
+      EntityType,
+      ReducerPath
+    >
+  } & {
+    [K in `delete${Capitalize<TagName>}`]: MutationDefinition<
+      string | number | Partial<EntityType>,
+      BaseQueryFn<
+        string | FetchArgs,
+        unknown,
+        FetchBaseQueryError,
+        unknown,
+        FetchBaseQueryMeta
+      >,
+      TagName,
+      void,
+      ReducerPath
+    >
+  }
+
+export function buildEndPoints<
+  EntityType,
+  TagName extends string,
+  ReducerPath extends string
+>(
+  repo: Repository<EntityType>,
+  tagName: TagName,
+  build: EndpointBuilder<
+    BaseQueryFn<
+      string | FetchArgs,
+      unknown,
+      FetchBaseQueryError,
+
+      object,
+      FetchBaseQueryMeta
+    >,
+    TagName,
+    ReducerPath
+  >
+
+): NameActions<EntityType, TagName, ReducerPath> {
+  return {
+    ["get" + tagName + "s"]: build.query({
+      queryFn: async (options: FindOptions<EntityType>) => {
+        return toQueryFn(() => repo.find({ ...options }))
+      },
+      providesTags: [tagName],
+    }),
+    ["add" + tagName]: build.mutation({
+      queryFn: async (item: Partial<EntityType>) => {
+        return toQueryFn(() => repo.insert(item))
+      },
+      invalidatesTags: [tagName],
+    }),
+    ["update" + tagName]: build.mutation({
+      queryFn: async (item: Partial<EntityType>) => {
+        return toQueryFn(() => repo.save(item))
+      },
+      invalidatesTags: [tagName],
+    }),
+    ["delete" + tagName]: build.mutation({
+      queryFn: async (id: string | number | Partial<EntityType>) => {
+        // @ts-expect-error id will work
+        return toQueryFn(() => repo.delete(id))
+      },
+      invalidatesTags: [tagName],
+    })
+  } as NameActions<EntityType, TagName, ReducerPath>
+
+}
+
+
+
+export async function toQueryFn<T>(what: () => Promise<T>, repo?: Repository<T>) {
+  try {
+    let data = await what();
+    if (repo)
+      data = repo.toJson(data);
+
+    return { data };
+  } catch (error) {
+    return {
+      error: {
+        data: error,
+        status: (error as ErrorInfo).httpStatusCode || 400
+      }
+    };
+  }
+}

--- a/src/redux/task.api.ts
+++ b/src/redux/task.api.ts
@@ -1,64 +1,18 @@
 import { baseApi } from "./base.api";
-import { remult } from "remult";
+import { remult, } from "remult";
 import { Task } from "../shared/entities/Task";
 import { TaskController } from "../shared/controllers/Tasks.controller";
+import { buildEndPoints, toQueryFn } from "./api.tools.ts";
+
 
 const taskRepo = remult.repo(Task);
 
 const taskApi = baseApi.injectEndpoints({
     endpoints: (build) => ({
-        getTasks: build.query({
-            queryFn: async ({ options }) => {
-                try {
-                    const data = taskRepo.toJson(await taskRepo.find({ ...options }));
-                    return { data };
-                } catch (error) {
-                    return { error };
-                }
-            },
-            providesTags: ["Task"],
-        }),
-        addTask: build.mutation({
-            queryFn: async (taskTitle: string) => {
-                try {
-                    const data = taskRepo.toJson(await taskRepo.insert({ title: taskTitle }));
-                    return { data };
-                } catch (error) {
-                    return { error };
-                }
-            },
-            invalidatesTags: ["Task"],
-        }),
-        deleteTask: build.mutation({
-            queryFn: async (task: Task) => {
-                try {
-                    const data = taskRepo.toJson(await taskRepo.delete(task));
-                    return { data };
-                } catch (error) {
-                    return { error };
-                }
-            },
-            invalidatesTags: ["Task"],
-        }),
-        updateTask: build.mutation({
-            queryFn: async (task: Task) => {
-                try {
-                    const data = taskRepo.toJson(await taskRepo.save(task));
-                    return { data };
-                } catch (error) {
-                    return { error };
-                }
-            },
-            invalidatesTags: ["Task"],
-        }),
+        ...buildEndPoints(taskRepo, "Task", build),
         setAllCompleted: build.mutation({
             queryFn: async (completed: boolean) => {
-                try {
-                    const data = taskRepo.toJson(await TaskController.setAllTasksCompleted(completed));
-                    return { data };
-                } catch (error) {
-                    return { error };
-                }
+                return toQueryFn(() => TaskController.setAllTasksCompleted(completed));
             },
             invalidatesTags: ["Task"],
         }),
@@ -66,3 +20,6 @@ const taskApi = baseApi.injectEndpoints({
 });
 
 export const { useGetTasksQuery, useAddTaskMutation, useDeleteTaskMutation, useUpdateTaskMutation, useSetAllCompletedMutation } = taskApi;
+
+
+

--- a/src/server/api.ts
+++ b/src/server/api.ts
@@ -1,19 +1,20 @@
-import { remultExpress } from "remult/remult-express";
-import { Task } from "../shared/entities/Task";
-import { TaskController } from "../shared/controllers/Tasks.controller";
-import { MongoClient } from "mongodb";
-import { MongoDataProvider } from "remult/remult-mongo";
+import { remultExpress } from "remult/remult-express"
+import { Task } from "../shared/entities/Task"
+import { TaskController } from "../shared/controllers/Tasks.controller"
+import { MongoClient } from "mongodb"
+import { MongoDataProvider } from "remult/remult-mongo"
 
 import dotenv from "dotenv"
 dotenv.config()
 
 export const api = remultExpress({
-    dataProvider: async () => {
-        const client = new MongoClient(process.env.MONGO_URI!);
-        await client.connect();
-        return new MongoDataProvider(client.db("remult-task-app"), client);
-    },
-    entities: [Task],
-    controllers: [TaskController],
-    getUser: (req) => req.session!["user"],
-});
+  dataProvider: async () => {
+    if (!process.env.MONGO_URI) return undefined
+    const client = new MongoClient(process.env.MONGO_URI!)
+    await client.connect()
+    return new MongoDataProvider(client.db("remult-task-app"), client)
+  },
+  entities: [Task],
+  controllers: [TaskController],
+  getUser: (req) => req.session!["user"],
+})

--- a/src/shared/entities/Task.ts
+++ b/src/shared/entities/Task.ts
@@ -6,7 +6,8 @@ import { Entity, Fields, Allow } from "remult";
     allowApiDelete: "admin",
 })
 export class Task {
-    @Fields.string({ dbName: "_id", valueConverter: { fieldTypeInDb: "dbid" } })
+    //    @Fields.string({ dbName: "_id", valueConverter: { fieldTypeInDb: "dbid" } })
+    @Fields.cuid()
     id = "";
     @Fields.string({
         validate: (task) => {


### PR DESCRIPTION
I tried to minimize the per entity boiler plate code, by creating a generic buildEndpoint method, that can work with any entity, and simplifying the task.api file

https://github.com/ChipLuxury-EWA/remult-mui-todoapp/compare/main...noam-honig:remult-mui-rtk-todoapp:main#diff-bc285bed75890914b5df927153dde12e6c55007f02003dedfcba481669759aee